### PR TITLE
Add External Apps page and navigation link

### DIFF
--- a/LW_Web/Controllers/ExternalAppsController.cs
+++ b/LW_Web/Controllers/ExternalAppsController.cs
@@ -1,0 +1,13 @@
+using System.Web.Mvc;
+
+namespace LW_Web.Controllers
+{
+    public class ExternalAppsController : Controller
+    {
+        // GET: ExternalApps
+        public ActionResult Index()
+        {
+            return View("ExternalApps");
+        }
+    }
+}

--- a/LW_Web/Views/Shared/ExternalApps.cshtml
+++ b/LW_Web/Views/Shared/ExternalApps.cshtml
@@ -1,0 +1,16 @@
+@{
+    Layout = "~/Views/Shared/_LayoutPage.cshtml";
+}
+
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <h4 class="header-title">External Apps</h4>
+                    <p>Links to external applications will appear here.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/LW_Web/Views/Shared/_LayoutPage.cshtml
+++ b/LW_Web/Views/Shared/_LayoutPage.cshtml
@@ -225,6 +225,7 @@
                                 <li><a href="~/PI">Inventory Counts</a></li>
                                 <li><a href="~/Laborer">Laborers</a></li>
                                 <li><a href="~/Vendor">Vendors</a></li>
+                                <li><a href="~/ExternalApps">External Apps</a></li>
                                 <li><a href="~/User">User Accounts</a></li>
                             </ul>
                         </div>


### PR DESCRIPTION
## Summary
- Add External Apps menu link under Administration navigation
- Implement ExternalAppsController with Index action
- Create placeholder External Apps view

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dedee579c8327a744d6bea64883a1